### PR TITLE
Server crashes during or near handshake

### DIFF
--- a/src/protocol/v3/v3-messages.ts
+++ b/src/protocol/v3/v3-messages.ts
@@ -121,7 +121,7 @@ function checkEntryValue(type: V3EntryType, valueObj: NTEntryValue) {
 }
 
 export function entryFlagsToUInt8(flags: V3EntryFlags): number {
-    return (flags.persistent ? 1 : 0);
+    return (typeof flags == "object" && flags !== null && flags.persistent ? 1 : 0);
 }
 
 export function UInt8ToEntryFlags(flagByte: number): V3EntryFlags {


### PR DESCRIPTION
It appears that either the client is not sending the `entryFlags`, or the server doesn't parse `entryFlags`. The server then crashes in `v3-messages.ts` in method `entryFlagsToUint8` when it tries to dereference undefined `flags`.

### To reproduce the issue:

- mkdir test-ntcore
- cd test-ntcore
- npm init -f -q
- npm install --save node-ntcore
- create `server.js` as follows:
```
const           ntCore = require("node-ntcore");
const           ntInst = ntCore.NetworkTableInstance.getDefault();
const           testTable = ntInst.getTable("/TestTable");

ntInst.setLogLevel("silly");
testTable.getEntry("Entry 1").setDouble("23");
ntInst.startServer("/tmp/nt.db");
```
- create `client.js` as follows:
```
const           ntCore = require("node-ntcore");
const           ntInst = ntCore.NetworkTableInstance.getDefault();
const           testTable = ntInst.getTable("/TestTable");

ntInst.setLogLevel("silly");
ntInst.startClient("127.0.0.1");
```
- In one window, run `node server.js`
- In another window, run `node client.js`
- The server will crash during negotiation.

### Notes
This is likely a fix that covers up the symptom rather than fixing the underlying cause. I suspect that either the client is not properly sending `entryFlags`, or the server is improperly parsing the received PDU, thereby neglecting to include `entryFlags` in the parsed message.

Alternatively, I may be misusing the API. If so, I'd be thrilled to be enlightened.